### PR TITLE
registered all features and added a structure example

### DIFF
--- a/src/main/java/com/zathrox/explorercraft/client/render/WizardRenderer.java
+++ b/src/main/java/com/zathrox/explorercraft/client/render/WizardRenderer.java
@@ -5,6 +5,7 @@ import com.zathrox.explorercraft.core.Explorercraft;
 import net.minecraft.client.renderer.entity.EntityRendererManager;
 import net.minecraft.client.renderer.entity.LivingRenderer;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -18,7 +19,7 @@ public class WizardRenderer extends LivingRenderer {
     }
 
     @Override
-    protected boolean canRenderName(Entity entity) {
+    protected boolean canRenderName(LivingEntity entity) {
         return true;
     }
 

--- a/src/main/java/com/zathrox/explorercraft/common/world/ExplorerFeature.java
+++ b/src/main/java/com/zathrox/explorercraft/common/world/ExplorerFeature.java
@@ -1,11 +1,34 @@
 package com.zathrox.explorercraft.common.world;
 
+import java.util.Locale;
+
 import com.zathrox.explorercraft.common.world.blockstateProvider.SnowdoniaFlowerBlockStateProvider;
-import com.zathrox.explorercraft.common.world.feature.*;
+import com.zathrox.explorercraft.common.world.feature.AshTreeFeature;
+import com.zathrox.explorercraft.common.world.feature.BambooTreeFeature;
+import com.zathrox.explorercraft.common.world.feature.ECBigTreeFeature;
+import com.zathrox.explorercraft.common.world.feature.ECBirchTreeFeature;
+import com.zathrox.explorercraft.common.world.feature.ECTreeFeature;
+import com.zathrox.explorercraft.common.world.feature.JapaneseMapleTreeFeature;
+import com.zathrox.explorercraft.common.world.feature.KwanzanCherryTreeFeature;
+import com.zathrox.explorercraft.common.world.feature.LotusFlowerFeature;
+import com.zathrox.explorercraft.common.world.feature.MudSurfaceBuilder;
+import com.zathrox.explorercraft.common.world.feature.NoctilucaFeature;
+import com.zathrox.explorercraft.common.world.feature.RicePaddyFeature;
+import com.zathrox.explorercraft.common.world.feature.SlimeBlockFeature;
+import com.zathrox.explorercraft.common.world.feature.TallDarkOakTreeFeature;
+import com.zathrox.explorercraft.common.world.feature.WildLeekFeature;
+import com.zathrox.explorercraft.common.world.feature.WillowTreeFeature;
 import com.zathrox.explorercraft.common.world.feature.structure.SlateDungeonFeature;
 import com.zathrox.explorercraft.common.world.feature.structure.WizardTowerFeature;
+import com.zathrox.explorercraft.common.world.feature.structure.WizardTowerPiecesTest;
+import com.zathrox.explorercraft.common.world.feature.structure.WizardTowerStructureTest;
+import com.zathrox.explorercraft.core.Explorercraft;
 import com.zathrox.explorercraft.core.registry.ExplorerBlocks;
+
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.registry.Registry;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.gen.GenerationStage.Decoration;
 import net.minecraft.world.gen.blockplacer.DoublePlantBlockPlacer;
 import net.minecraft.world.gen.blockplacer.SimpleBlockPlacer;
 import net.minecraft.world.gen.blockstateprovider.SimpleBlockStateProvider;
@@ -13,24 +36,51 @@ import net.minecraft.world.gen.blockstateprovider.WeightedBlockStateProvider;
 import net.minecraft.world.gen.feature.BlockClusterFeatureConfig;
 import net.minecraft.world.gen.feature.Feature;
 import net.minecraft.world.gen.feature.NoFeatureConfig;
-import net.minecraft.world.gen.feature.TreeFeature;
+import net.minecraft.world.gen.feature.structure.IStructurePieceType;
+import net.minecraft.world.gen.feature.structure.Structure;
 import net.minecraft.world.gen.placement.CountConfig;
 import net.minecraft.world.gen.placement.FrequencyConfig;
 import net.minecraft.world.gen.placement.IPlacementConfig;
 import net.minecraft.world.gen.placement.Placement;
 import net.minecraft.world.gen.surfacebuilders.SurfaceBuilder;
 import net.minecraft.world.gen.surfacebuilders.SurfaceBuilderConfig;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.IForgeRegistry;
+import net.minecraftforge.registries.IForgeRegistryEntry;
 
 public class ExplorerFeature {
 
+    //Surfacebuilders
+    public static final SurfaceBuilder<SurfaceBuilderConfig> MUD_SURFACE_BUILDER = new MudSurfaceBuilder(SurfaceBuilderConfig::deserialize);
+    public static final SurfaceBuilderConfig MUD_SURFACE = new SurfaceBuilderConfig(ExplorerBlocks.MUD.getDefaultState(), ExplorerBlocks.MUD.getDefaultState(), ExplorerBlocks.MUD.getDefaultState());
+
+	public static void surfacebuilderRegistering(final RegistryEvent.Register<SurfaceBuilder<?>> event){
+		IForgeRegistry<SurfaceBuilder<?>> registry = event.getRegistry();
+		register(registry, MUD_SURFACE_BUILDER, "mud_surface_builder");
+	}
+	
+	
+    //Placement
+    public static final Placement<FrequencyConfig> COUNT_HEIGHT_100 = register("count_height_100", new AtHeight100(FrequencyConfig::deserialize));
+
+    private static <T extends IPlacementConfig, G extends Placement<T>> G register(String key, G p_214999_1_) {
+        return (G)(Registry.<Placement<?>>register(Registry.DECORATOR, key, p_214999_1_));
+    }
+
+    
+	//Feature configs
     public static final BlockClusterFeatureConfig SNOWDONIA_FLOWER_CONFIG = (new BlockClusterFeatureConfig.Builder(new SnowdoniaFlowerBlockStateProvider(), new SimpleBlockPlacer())).tries(64).build();
     public static final BlockClusterFeatureConfig GREEN_GLOWSHROOM_CONFIG = (new BlockClusterFeatureConfig.Builder(new SimpleBlockStateProvider(ExplorerBlocks.GREEN_MUSHROOM.getDefaultState()), new SimpleBlockPlacer())).tries(64).func_227317_b_().build();
     public static final BlockClusterFeatureConfig PINK_GLOWSHROOM_CONFIG = (new BlockClusterFeatureConfig.Builder(new SimpleBlockStateProvider(ExplorerBlocks.PINK_MUSHROOM.getDefaultState()), new SimpleBlockPlacer())).tries(64).func_227317_b_().build();
     public static final BlockClusterFeatureConfig LUPINE_CONFIG = (new BlockClusterFeatureConfig.Builder((new WeightedBlockStateProvider()).func_227407_a_(ExplorerBlocks.LUPINE.getDefaultState(), 2), new SimpleBlockPlacer())).tries(64).build();
     public static final BlockClusterFeatureConfig CATTAIL_CONFIG = (new BlockClusterFeatureConfig.Builder(new SimpleBlockStateProvider(ExplorerBlocks.CATTAIL.getDefaultState()), new SimpleBlockPlacer())).tries(32).build();
     public static final BlockClusterFeatureConfig TALL_CATTAIL_CONFIG = (new BlockClusterFeatureConfig.Builder(new SimpleBlockStateProvider(ExplorerBlocks.TALL_CATTAIL.getDefaultState()), new DoublePlantBlockPlacer())).tries(64).func_227317_b_().build();
-
-    public static final Placement<FrequencyConfig> COUNT_HEIGHT_100 = register("count_height_100", new AtHeight100(FrequencyConfig::deserialize));
+    
+    
+    //Features & Structures
+	public static final DeferredRegister<Feature<?>> FEATURES = new DeferredRegister<>(ForgeRegistries.FEATURES, Explorercraft.MOD_ID);
 
     public static final Feature<NoFeatureConfig> FANCY_TREE = new ECBigTreeFeature(NoFeatureConfig::deserialize);
     public static final Feature<NoFeatureConfig> BIRCH_TREE = new ECBirchTreeFeature(NoFeatureConfig::deserialize, false);
@@ -51,29 +101,97 @@ public class ExplorerFeature {
 
     public static final Feature<NoFeatureConfig> SLIME_BLOCK = new SlimeBlockFeature(NoFeatureConfig::deserialize);
 
-
     public static final Feature<NoFeatureConfig> TALL_DARK_OAK_TREE = new TallDarkOakTreeFeature(NoFeatureConfig::deserialize);
     public static final Feature<NoFeatureConfig> WILLOW_TREE = new WillowTreeFeature(NoFeatureConfig::deserialize);
 
+    
+    
+	//feature registering
+	public static void featureRegistering(final RegistryEvent.Register<Feature<?>> event){
+		
+		IForgeRegistry<Feature<?>> registry = event.getRegistry();
+		
+		//features
+		register(registry, FANCY_TREE, "fancy_tree");
+		register(registry, BIRCH_TREE, "birch_tree");
+		register(registry, NORMAL_TREE, "normal_tree");
 
+		register(registry, WILD_LEEK, "wild_leek");
+		register(registry, RICE_PADDY, "rice_paddy");
+		register(registry, LOTUS_FLOWERS, "lotus_flowers");
 
-    public static final SurfaceBuilder<SurfaceBuilderConfig> MUD_SURFACE_BUILDER = new MudSurfaceBuilder(SurfaceBuilderConfig::deserialize);
-    public static final SurfaceBuilderConfig MUD_SURFACE = new SurfaceBuilderConfig(ExplorerBlocks.MUD.getDefaultState(), ExplorerBlocks.MUD.getDefaultState(), ExplorerBlocks.MUD.getDefaultState());
+		register(registry, ASH_TREE, "ash_tree");
+		register(registry, BAMBOO_TREE, "bamboo_tree");
+		register(registry, CHERRY_TREE, "cherry_tree");
+		register(registry, MAPLE_TREE, "maple_tree");
+		register(registry, NOCTILUCA, "noctiluca");
 
-    //public static final Feature<NoFeatureConfig> TEST2 = new TestFeature(NoFeatureConfig::deserialize, false);
-/*    public static final Structure<NoFeatureConfig> TEST  = (Structure<NoFeatureConfig>) Structures.register("Test", new TestStructure(NoFeatureConfig::deserialize));
+		register(registry, WIZARD_TOWER, "wizard_tower");
+		register(registry, SLATE_DUNGEON, "slate_dungeon");
 
-    public static void registerFeatures(IForgeRegistry<Feature<?>> registry) {
+		register(registry, SLIME_BLOCK, "slime_block");
 
-        registry.register(WIZARD_TOWER.setRegistryName(Explorercraft.MOD_ID, "wizard_tower"));
-        registry.register(TEST.setRegistryName(Explorercraft.MOD_ID, "test"));
-        Feature.STRUCTURES.put("Wizard_Tower".toLowerCase(Locale.ROOT), (Structure<?>) WIZARD_TOWER);
-        Feature.STRUCTURES.put("Test".toLowerCase(Locale.ROOT), TEST);
+		register(registry, TALL_DARK_OAK_TREE, "tall_dark_oak_tree");
+		register(registry, WILLOW_TREE, "willow_tree");
 
-    }*/
+		
+		
+		//Ok so thanks to a Forge oversight, if you want your structure to spawn in 
+		//the Overworld in your modded biomes, you need to add it to at least one 
+		//vanilla biome as well. From what I can tell, Forge forgot to make a workaround
+		//for how vanilla will check if a structure exists in a biomeprovider/chunkgenerator
+		//and so it only checks vanilla biomes to see if the world has a structure instead 
+		//of all biomes that's actually spawning in the Overwolrd. (this works perfectly fine 
+		//in modded worldtypes, dimension, chunkgenerators/biomeproviders, etc. Only an issue in
+		//vanilla. Time for me to open up a new Forge issue lol)
+		//structures
+		register(registry, WIZARD_TOWER_STRUCTURE, "wizard_tower_piece");
+		
+		//Adds the structure to all biome's feature list. This makes it so the structure
+		//does not get cut off if it ends up spawning on the edge of a biome and part of
+		//it goes into the other biome that it doesn't have the structure added by .addStructure()
+		//
+		//To specify a biome for the structure to be able to spawn in, do .addStructure() but again
+		//be sure to also do .addFeature() so the biomes can know to actually make the structure's pieces.
+		//
+		//A way to think about is .addStructure specifies valid biomes to spawn in and .addFeature says 
+		//which biomes can actually generate the parts of the structure.
+		for(Biome biome : ForgeRegistries.BIOMES){
+			biome.addFeature(Decoration.SURFACE_STRUCTURES, WIZARD_TOWER_STRUCTURE.withConfiguration(NoFeatureConfig.NO_FEATURE_CONFIG));
+		}
+		// Add the following to any biome you want to spawn this structure in
+		// biome.addStructure(WIZARD_TOWER_STRUCTURE.withConfiguration(NoFeatureConfig.NO_FEATURE_CONFIG));
+		
+		//register the pieces of the structures
+		register(WIZARD_TOWER_PIECE, "wizard_tower_piece");
+	}
 
-    private static <T extends IPlacementConfig, G extends Placement<T>> G register(String key, G p_214999_1_) {
-        return (G)(Registry.<Placement<?>>register(Registry.DECORATOR, key, p_214999_1_));
-    }
-
+	
+	//True Structure test example
+	public static final Structure<NoFeatureConfig> WIZARD_TOWER_STRUCTURE = new WizardTowerStructureTest(NoFeatureConfig::deserialize);
+	public static IStructurePieceType WIZARD_TOWER_PIECE = WizardTowerPiecesTest.Piece::new;
+	
+	/**
+	 * For registering structure pieces so Minecraft doesn't spam the logs saying the pieces aren't registered yet
+	 */
+	public static IStructurePieceType register(IStructurePieceType pieceType, String key){
+		return Registry.register(Registry.STRUCTURE_PIECE, key.toLowerCase(Locale.ROOT), pieceType);
+	}
+	
+	/**
+	 * Helper method to quickly register features, blocks, items, structures, biomes, anything that can be registered.
+	 * 
+	 * If you want to use the regular registry event, you can use this to quickly register stuff.
+	 *     
+	 * Example: 
+	 * 	public static final RegistryObject<Feature<NoFeatureConfig>> WILLOW_TREE;
+	 * 	registeryEvent(event e){
+	 * 		WILLOW_TREE =  register(e.registry, WILLOW_TREE, "willow_tree");
+	 * 	}	
+	 */
+	public static <T extends IForgeRegistryEntry<T>> T register(IForgeRegistry<T> registry, T entry, String registryKey){
+		entry.setRegistryName(new ResourceLocation(Explorercraft.MOD_ID, registryKey.toLowerCase().replace(' ', '_')));
+		registry.register(entry);
+		return entry;
+	}
 }

--- a/src/main/java/com/zathrox/explorercraft/common/world/biome/SnowdoniaBiome.java
+++ b/src/main/java/com/zathrox/explorercraft/common/world/biome/SnowdoniaBiome.java
@@ -30,6 +30,7 @@ public class SnowdoniaBiome extends Biome {
         super((new Builder()).surfaceBuilder(SurfaceBuilder.DEFAULT, SurfaceBuilder.GRASS_DIRT_GRAVEL_CONFIG).precipitation(RainType.RAIN).category(Category.FOREST).depth(-0.15F).scale(1.2F).temperature(0.7F).waterColor(4020182).waterFogColor(329011).downfall(0.8F).parent((String)null));
         this.addStructure(Feature.MINESHAFT.withConfiguration(new MineshaftConfig(0.004D, MineshaftStructure.Type.NORMAL)));
         this.addStructure(Feature.STRONGHOLD.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG));
+        //this.addStructure(ExplorerFeature.WIZARD_TOWER_STRUCTURE.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG));
 
         this.addFeature(GenerationStage.Decoration.SURFACE_STRUCTURES, ExplorerFeature.WIZARD_TOWER.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG).withPlacement(Placement.COUNT_CHANCE_HEIGHTMAP.configure(new HeightWithChanceConfig(EntityConfig.wizard_weight.get(), 1F))));
         this.addFeature(GenerationStage.Decoration.UNDERGROUND_STRUCTURES, ExplorerFeature.SLATE_DUNGEON.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG).withPlacement(Placement.DUNGEONS.configure(new ChanceConfig(GeneralConfig.slateDungeonRarity.get()))));

--- a/src/main/java/com/zathrox/explorercraft/common/world/feature/structure/WizardTowerPiecesTest.java
+++ b/src/main/java/com/zathrox/explorercraft/common/world/feature/structure/WizardTowerPiecesTest.java
@@ -1,0 +1,106 @@
+package com.zathrox.explorercraft.common.world.feature.structure;
+
+import java.util.List;
+import java.util.Random;
+
+import com.zathrox.explorercraft.common.world.ExplorerFeature;
+import com.zathrox.explorercraft.core.Explorercraft;
+
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.util.Mirror;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.Rotation;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.math.MutableBoundingBox;
+import net.minecraft.world.IWorld;
+import net.minecraft.world.gen.ChunkGenerator;
+import net.minecraft.world.gen.feature.structure.IStructurePieceType;
+import net.minecraft.world.gen.feature.structure.StructurePiece;
+import net.minecraft.world.gen.feature.structure.TemplateStructurePiece;
+import net.minecraft.world.gen.feature.template.PlacementSettings;
+import net.minecraft.world.gen.feature.template.Template;
+import net.minecraft.world.gen.feature.template.TemplateManager;
+
+public class WizardTowerPiecesTest
+{
+	public static void createPieces(TemplateManager templateManager, BlockPos blockPos, Rotation rotation, List<StructurePiece> components, Random random) {
+        ResourceLocation wizardTowerRL = new ResourceLocation(Explorercraft.MOD_ID, "wizard_tower_v2");
+		Template template = templateManager.getTemplate(wizardTowerRL);
+
+        if (template == null) {
+            System.out.println("Could not find structure at " + new ResourceLocation(Explorercraft.MOD_ID, "structures/wizard_tower_v2"));
+            return;
+        }
+        components.add(new WizardTowerPiecesTest.Piece(templateManager, wizardTowerRL, blockPos, rotation));
+	}
+
+	public static class Piece extends TemplateStructurePiece {
+		private final ResourceLocation resourceLocation;
+		private final Rotation rotation;
+
+	  public Piece(TemplateManager templateManager, ResourceLocation resourceLocation, BlockPos position, Rotation rotation) {
+		 super(ExplorerFeature.WIZARD_TOWER_PIECE, 0);
+		 
+		 this.rotation = rotation;
+		 this.templatePosition = position;
+		 this.resourceLocation = resourceLocation;
+		 this.func_207614_a(templateManager);
+	  }
+
+	  public Piece(TemplateManager templateManager, CompoundNBT data) {
+		 super(IStructurePieceType.IGLU, data);
+		 this.resourceLocation = new ResourceLocation(data.getString("Template"));
+		 this.rotation = Rotation.valueOf(data.getString("Rot"));
+		 this.func_207614_a(templateManager);
+	  }
+
+	  /**
+	   * Sets up the placement setting for the pieces
+	   */
+	  private void func_207614_a(TemplateManager templateManager) {
+		 Template template = templateManager.getTemplateDefaulted(this.resourceLocation);
+		 PlacementSettings placementSettings = (new PlacementSettings()).setMirror(Mirror.NONE).setRotation(rotation).setIgnoreEntities(false).setChunk(null);
+		 this.setup(template, this.templatePosition, placementSettings);
+	  }
+
+	  /**
+	   * (abstract) Helper method to read subclass data from NBT
+	   */
+	  protected void readAdditional(CompoundNBT tagCompound) {
+		 super.readAdditional(tagCompound);
+		 tagCompound.putString("Template", this.resourceLocation.toString());
+		 tagCompound.putString("Rot", this.rotation.name());
+	  }
+
+	  /**
+	   * Fires for each Structure Block that is set to data mode.
+	   * Use this by placing a data block name "chest" where you
+	   * want a chest and then replace it with a chest here and set
+	   * the loottable. This also works for placing mobs, dispensers, 
+	   * randomizing blocks, etc...
+	   */
+	  protected void handleDataMarker(String function, BlockPos pos, IWorld worldIn, Random rand, MutableBoundingBox sbb) {
+//		 if ("chest".equals(function)) {
+//			worldIn.setBlockState(pos, Blocks.CHEST.getDefaultState(), 3);
+//			TileEntity tileentity = worldIn.getTileEntity(pos);
+//			if (tileentity instanceof ChestTileEntity) {
+//			   ((ChestTileEntity)tileentity).setLootTable(LootTables.CHESTS_IGLOO_CHEST, rand.nextLong());
+//			}
+//
+//		 }
+	  }
+
+	  public boolean func_225577_a_(IWorld world, ChunkGenerator<?> chunkGenerator, Random random, MutableBoundingBox boundingBox, ChunkPos chunkPos) {
+		 
+		 BlockPos blockposOffset = new BlockPos(3, -4, 2);
+		 PlacementSettings placementSettings = (new PlacementSettings()).setMirror(Mirror.NONE).setRotation(rotation).setIgnoreEntities(false).setChunk(null);
+		 BlockPos finalBlockpos = this.templatePosition.add(Template.transformedBlockPos(placementSettings, blockposOffset));
+		 this.templatePosition = finalBlockpos;
+		 
+		 //not sure what this does
+		 boolean validConstruction = super.func_225577_a_(world, chunkGenerator, random, boundingBox, chunkPos);
+		 return validConstruction;
+	  }
+	}
+}

--- a/src/main/java/com/zathrox/explorercraft/common/world/feature/structure/WizardTowerStructureTest.java
+++ b/src/main/java/com/zathrox/explorercraft/common/world/feature/structure/WizardTowerStructureTest.java
@@ -1,0 +1,143 @@
+package com.zathrox.explorercraft.common.world.feature.structure;
+
+import java.util.Random;
+import java.util.function.Function;
+
+import com.mojang.datafixers.Dynamic;
+import com.zathrox.explorercraft.core.Explorercraft;
+
+import net.minecraft.util.Rotation;
+import net.minecraft.util.SharedSeedRandom;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.math.MutableBoundingBox;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.BiomeManager;
+import net.minecraft.world.gen.ChunkGenerator;
+import net.minecraft.world.gen.Heightmap;
+import net.minecraft.world.gen.feature.NoFeatureConfig;
+import net.minecraft.world.gen.feature.structure.Structure;
+import net.minecraft.world.gen.feature.structure.StructureStart;
+import net.minecraft.world.gen.feature.template.TemplateManager;
+
+
+public class WizardTowerStructureTest extends Structure<NoFeatureConfig>{
+
+	public WizardTowerStructureTest(Function<Dynamic<?>, ? extends NoFeatureConfig> config){
+		super(config);
+	}
+
+
+	/**
+	 * Will check to see if the chunk coordinate is valid for spawning by using algorithm that spaces out each valid
+	 * position between a range.
+	 */
+	@Override
+	protected ChunkPos getStartPositionForPosition(ChunkGenerator<?> chunkGenerator, Random random, int x, int z, int spacingOffsetsX, int spacingOffsetsZ){
+		//This will make each valid coordinate for the Wizard Tower be between 4 to 8 chunks from each other
+		int maxDistance = 8;
+		int minDistance = 4;
+		if (minDistance == 0)
+		{
+			minDistance = 1;
+		}
+		int k = x + maxDistance * spacingOffsetsX;
+		int l = z + maxDistance * spacingOffsetsZ;
+		int i1 = k < 0 ? k - maxDistance + 1 : k;
+		int j1 = l < 0 ? l - maxDistance + 1 : l;
+		int targetChunkX = i1 / maxDistance;
+		int targetChunkZ = j1 / maxDistance;
+		((SharedSeedRandom) random).setLargeFeatureSeedWithSalt(chunkGenerator.getSeed(), targetChunkX, targetChunkZ, 54354657); //the number here is a seed modifier. Have this always be unique compared to other structures so the valid chunk position is always different.
+		targetChunkX = targetChunkX * maxDistance;
+		targetChunkZ = targetChunkZ * maxDistance;
+		targetChunkX = targetChunkX + random.nextInt(maxDistance - minDistance);
+		targetChunkZ = targetChunkZ + random.nextInt(maxDistance - minDistance);
+		return new ChunkPos(targetChunkX, targetChunkZ);
+	}
+
+
+	/**
+	 * This determines if the spot given is a valid chunk to spawn in by algorithm and that the biome contains the structure
+	 * as well.
+	 */
+	@Override
+	public boolean func_225558_a_(BiomeManager biomeManager, ChunkGenerator<?> chunkGenerator, Random random, int chunkPosX, int chunkPosZ, Biome biome){
+		//check if the algorithm says the chunk is a valid spot 
+		ChunkPos chunkpos = this.getStartPositionForPosition(chunkGenerator, random, chunkPosX, chunkPosZ, 0, 0);
+		if (chunkPosX == chunkpos.x && chunkPosZ == chunkpos.z){
+			int landHeight = chunkGenerator.func_222529_a(chunkPosX * 16, chunkPosZ * 16, Heightmap.Type.MOTION_BLOCKING_NO_LEAVES);
+
+			//check if the biome actually has the structure added to it
+			//and also checks to make sure one corner of chunk isn't too high (not a perfect check)
+			if (chunkGenerator.hasStructure(biome, this) && landHeight <= 100){
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+
+	@Override
+	public Structure.IStartFactory getStartFactory(){
+		return WizardTowerStructureTest.Start::new;
+	}
+
+
+	@Override
+	public String getStructureName(){
+		//what the /locate command will see. 
+		//If you do not add the mod's mod id, then forge will
+		//put it under minecraft's namespace which would make it be "minecraft:wizard_tower_structure"
+		return Explorercraft.MOD_ID + ":wizard_tower_structure";
+	}
+
+
+	/**
+	 * legacy code that mojang hasn't removed yet. Does nothing
+	 */
+	@Override
+	public int getSize(){
+		return 8;
+	}
+
+	public static class Start extends StructureStart{
+		public Start(Structure<?> structureIn, int chunkX, int chunkZ, MutableBoundingBox mutableBoundingBox, int referenceIn, long seedIn){
+			super(structureIn, chunkX, chunkZ, mutableBoundingBox, referenceIn, seedIn);
+		}
+
+		/**
+		 * Begins construction of the structure layout and everything and passes it into the components variable so that
+		 * Minecraft can read the pieces from there and create the full structure piece by piece later.
+		 */
+		@Override
+		public void init(ChunkGenerator<?> chunkGenerator, TemplateManager templateManagerIn, int chunkX, int chunkZ, Biome biomeIn){
+			int x = chunkX * 16;
+			int z = chunkZ * 16;
+			Rotation rotation = Rotation.values()[this.rand.nextInt(Rotation.values().length)]; //random rotation of the structure
+			 
+			//not correctly aligned to tower's door. You might have to move this elsewhere or something to make it work 
+			int xOffset = 9;
+			int zOffset = 5;
+			if (rotation == Rotation.CLOCKWISE_90)
+			{
+				xOffset = -xOffset;
+			}
+			else if (rotation == Rotation.CLOCKWISE_180)
+			{
+				xOffset = -xOffset;
+				zOffset = -zOffset;
+			}
+			else if (rotation == Rotation.COUNTERCLOCKWISE_90)
+			{
+				zOffset = -zOffset;
+			}
+			int landHeight = chunkGenerator.func_222529_a(x+xOffset, z+zOffset, Heightmap.Type.WORLD_SURFACE);
+			System.out.println(x+xOffset +", "+ (z+zOffset));
+			
+			BlockPos blockpos = new BlockPos(x, landHeight, z); //pass in position so the piece knows where to do the height offset check at
+			WizardTowerPiecesTest.createPieces(templateManagerIn, blockpos, rotation, this.components, this.rand); //create the layout of structure
+			this.recalculateStructureSize(); //Sets the bounding box correctly to the entire structure now
+		}
+	}
+}

--- a/src/main/java/com/zathrox/explorercraft/core/Explorercraft.java
+++ b/src/main/java/com/zathrox/explorercraft/core/Explorercraft.java
@@ -1,15 +1,24 @@
 package com.zathrox.explorercraft.core;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.zathrox.explorercraft.common.world.ExplorerFeature;
 import com.zathrox.explorercraft.core.proxy.ClientProxy;
 import com.zathrox.explorercraft.core.proxy.CommonProxy;
 import com.zathrox.explorercraft.core.proxy.ServerProxy;
 import com.zathrox.explorercraft.core.registry.ExplorerBiomes;
-import net.minecraftforge.eventbus.api.IEventBus;
+
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.gen.GenerationStage.Decoration;
+import net.minecraft.world.gen.feature.Feature;
+import net.minecraft.world.gen.feature.NoFeatureConfig;
+import net.minecraft.world.gen.surfacebuilders.SurfaceBuilder;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import net.minecraftforge.registries.ForgeRegistries;
 
 // The value here should match an entry in the META-INF/mods.toml file
 @Mod(Explorercraft.MOD_ID)
@@ -27,8 +36,21 @@ public class Explorercraft {
 
         instance = this;
         proxy = DistExecutor.runForDist(() -> ClientProxy::new, () -> ServerProxy::new);
-
-
     }
 
+	@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
+	public static class RegistryEvents
+	{
+		@SubscribeEvent
+		public static void featureRegistery(final RegistryEvent.Register<Feature<?>> event)
+		{
+			ExplorerFeature.featureRegistering(event);
+		}
+		
+		@SubscribeEvent
+		public static void surfacebuilderRegistery(final RegistryEvent.Register<SurfaceBuilder<?>> event)
+		{
+			ExplorerFeature.surfacebuilderRegistering(event);
+		}
+	}
 }


### PR DESCRIPTION
This can be cleaned up to a format you like better and stuff moved to where you like it. Though all features are now registered properly and I also threw in registering a surfacebuilder too although practically no mod ever pulls surfacebuilders from the registry. Though it doesn't hurt to register it just in case.

The reason why you weren't able to get the /locate command working with the wizard tower and dungeon was because those weren't actually structure. they were just normal Features. Structure are a subset of Features and are implemented in a different way. 

To help you get started, I converted your Wizard Tower into a rough structure (based off of Vanilla's Igloo structure) and if you add it to a modded biome and at least one vanilla biome, it'll spawn and the /locate command can find it (has to be added to at least one vanilla biome when trying to spawn the structure in a vanilla dimension with vanilla chunkgenerator/biomeprovider because of a forge oversight with patching how vanilla finds and spawns structure) 

However, the new Wizard Tower structure will not spawn and isn't placed perfectly but it is a start and you can play around with it! Though you can just ignore the part about creating structures if it's too much effort and just keep the wizard tower/dungeon as normal features like they currently are. I hope this helps! 